### PR TITLE
Updated the ooxml_util_pkg

### DIFF
--- a/ora/ooxml_util_pkg.pkb
+++ b/ora/ooxml_util_pkg.pkb
@@ -58,6 +58,44 @@ begin
 end get_xml;
 
 
+function get_worksheets_list( p_xlsx in blob ) return t_xlsx_sheet_properties
+as
+    l_returnvalue       t_xlsx_sheet_properties;
+    l_xml               xmltype;
+begin
+    
+    /* 
+    
+    Purpose:      get an array of the worksheets in the workbook
+    
+    Remarks:       
+    
+    Who     Date        Description 
+    ------  ----------  -------------------------------- 
+    JMW     02.03.2016  Created 
+    
+    */ 
+    
+    l_xml := get_xml( p_xlsx, 'xl/workbook.xml' );
+    
+    select xml.r_id, xml.sheetid, xml.name
+        bulk collect into l_returnvalue
+      from xmltable( xmlnamespaces( default 'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
+                         'http://schemas.openxmlformats.org/officeDocument/2006/relationships' AS "r" ),
+                    '/workbook/sheets/sheet'
+                    passing l_xml
+                    columns
+                        r_id varchar2(255) path '@r:id',
+                        sheetid number path '@sheetId',
+                        name varchar2(31) path '@name' ) xml
+    where xml.r_id is not null
+    order by xml.sheetid;
+    
+    return l_returnvalue;
+    
+end get_worksheets_list;
+
+
 function get_docx_properties (p_docx in blob) return t_docx_properties
 as
   l_returnvalue t_docx_properties;

--- a/ora/ooxml_util_pkg.pks
+++ b/ora/ooxml_util_pkg.pks
@@ -77,7 +77,18 @@ as
   );
 
   type t_xlsx_sheet is table of t_xlsx_cell index by varchar2(20);
-
+  
+  type t_xlsx_sheet_attributes is record (
+      r_id    varchar2(255),
+      sheetid number,
+      name    varchar2(31)
+  );
+  
+  type t_xlsx_sheet_properties is table of t_xlsx_sheet_attributes index by pls_integer;
+  
+  -- get list of xlsx worksheets
+  function get_worksheets_list( p_xlsx in blob ) return t_xlsx_sheet_properties;
+  
   -- get docx properties
   function get_docx_properties (p_docx in blob) return t_docx_properties;
 


### PR DESCRIPTION
Added a new function within the ooxml_util_pkg that will return a collection of the worksheet records that include the name of the worksheet, the sheet ID of the worksheet, and the relationship ID for the worksheet. This will allow for the ability to look-up worksheets and parse them without needing to know what the worksheet's name is in advance. Also, created two new types to support this function.