### PR TITLE
Email validation was changed to follow RFC 5322 standard

### DIFF
--- a/ora/regexp_util_pkg.pks
+++ b/ora/regexp_util_pkg.pks
@@ -16,7 +16,7 @@ as
   g_exp_bind_vars                constant varchar2(255) := ':\w+';
   g_exp_hyperlinks               constant varchar2(255) := '<a href="[^"]+">[^<]+</a>';
   g_exp_ip_addresses             constant varchar2(255) := '(\d{1,3}\.){3}\d{1,3}';
-  g_exp_email_addresses          constant varchar2(255) := '[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}';
+  g_exp_email_addresses          constant varchar2(255) := '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$';
   g_exp_email_address_list       constant varchar2(255) := '^((\s*[a-zA-Z0-9\._%-]+@[a-zA-Z0-9\.-]+\.[a-zA-Z]{2,4}\s*[,;:]){1,100}?)?(\s*[a-zA-Z0-9\._%-]+@[a-zA-Z0-9\.-]+\.[a-zA-Z]{2,4})*$';
   g_exp_double_words             constant varchar2(255) := ' ([A-Za-z]+) \1';
   g_exp_cc_visa                  constant varchar2(255) := '^4[0-9]{12}(?:[0-9]{3})?$';

--- a/ora/validation_util_pkg.pkb
+++ b/ora/validation_util_pkg.pkb
@@ -12,59 +12,9 @@ as
   MBR     23.10.2011  Created
  
   */
- 
- 
+
+
 function is_valid_email (p_value in varchar2) return boolean
-as
-  l_dot_pos                      number;
-  l_at_pos                       number;
-  l_str_length                   number;
-  l_returnvalue                  boolean := true;
-begin
- 
-  /*
- 
-  Purpose:      returns true if value is valid email address
- 
-  Remarks:      Written by Anil Passi, see http://oracle.anilpassi.com/validate-email-pl-sql-2.html
- 
-  Who     Date        Description
-  ------  ----------  --------------------------------
-  MBR     23.10.2011  Created
-  MBR     26.10.2011  Added check against multiple at signs
- 
-  */
-
-  if p_value is null then
-    l_returnvalue := false;
-  else
-
-    l_dot_pos := instr(p_value, '.');
-    l_at_pos := instr(p_value, '@');
-    
-    l_str_length := length(p_value);
-    
-    if ((l_dot_pos = 0) or (l_at_pos = 0) or (l_dot_pos = l_at_pos + 1) or (l_at_pos = 1) or (l_at_pos = l_str_length) or (l_dot_pos = l_str_length)) then
-      l_returnvalue := false;
-    end if;
-
-    if instr(substr(p_value, l_at_pos), '.') = 0 then
-      l_returnvalue := false;
-    end if;
-
-    if instr(substr(p_value, l_at_pos + 1), '@') > 0 then
-      l_returnvalue := false;
-    end if;
-
-
-  end if;  
-  
-  return l_returnvalue;
- 
-end is_valid_email;
-
-
-function is_valid_email2 (p_value in varchar2) return boolean
 as
   l_value       varchar2(32000);
   l_returnvalue boolean;
@@ -79,18 +29,15 @@ begin
   Who     Date        Description
   ------  ----------  --------------------------------
   MBR     23.10.2011  Created
+  Tim N   01.04.2016  Enhancements
  
   */
-  
-  if p_value is null then
-    l_returnvalue := false;
-  else
-    l_returnvalue := regexp_replace(p_value, regexp_util_pkg.g_exp_email_addresses, null) is null;
-  end if;
-  
+
+  l_returnvalue := regexp_like(p_value, regexp_util_pkg.g_exp_email_addresses);
+
   return l_returnvalue;
- 
-end is_valid_email2;
+
+end is_valid_email;
  
 
 function is_valid_email_list (p_value in varchar2) return boolean
@@ -107,17 +54,14 @@ begin
   Who     Date        Description
   ------  ----------  --------------------------------
   MBR     23.10.2011  Created
+  Tim N   01.04.2016  Enhancements
  
   */
-  
-  if p_value is null then
-    l_returnvalue := false;
-  else
-    l_returnvalue := regexp_replace(p_value, regexp_util_pkg.g_exp_email_address_list, null) is null;
-  end if; 
+
+  l_returnvalue := regexp_like(p_value, regexp_util_pkg.g_exp_email_address_list);
 
   return l_returnvalue;
- 
+
 end is_valid_email_list;
 
 

--- a/ora/validation_util_pkg.pkb
+++ b/ora/validation_util_pkg.pkb
@@ -38,7 +38,22 @@ begin
   return l_returnvalue;
 
 end is_valid_email;
+
+
+function is_valid_email2 (p_value in varchar2) return boolean
+as
+begin
+
+ /*
  
+  Purpose:      backward compatibility only
+ 
+ */
+
+  return is_valid_email(p_value);
+
+end is_valid_email2;
+
 
 function is_valid_email_list (p_value in varchar2) return boolean
 as

--- a/ora/validation_util_pkg.pks
+++ b/ora/validation_util_pkg.pks
@@ -17,9 +17,6 @@ as
   -- returns true if value is valid email address
   function is_valid_email (p_value in varchar2) return boolean;
 
-  -- returns true if value is valid email address
-  function is_valid_email2 (p_value in varchar2) return boolean;
- 
   -- returns true if value is valid email address list
   function is_valid_email_list (p_value in varchar2) return boolean;
  

--- a/ora/validation_util_pkg.pks
+++ b/ora/validation_util_pkg.pks
@@ -17,6 +17,9 @@ as
   -- returns true if value is valid email address
   function is_valid_email (p_value in varchar2) return boolean;
 
+  -- returns true if value is valid email address
+  function is_valid_email2 (p_value in varchar2) return boolean;
+
   -- returns true if value is valid email address list
   function is_valid_email_list (p_value in varchar2) return boolean;
  


### PR DESCRIPTION
The email regexp was improved to be case-insensitive.
The old is_valid_email() function was removed.
The is_valid_email2() function was renamed to is_valid_email() in order to be more user-friendly.
Code readability was improved.