### PR TITLE
Modified ooxml_util_pkg functions 

### DIFF
--- a/ora/ooxml_util_pkg.pkb
+++ b/ora/ooxml_util_pkg.pkb
@@ -310,7 +310,7 @@ end get_xlsx_properties;
 
 function get_xlsx_column_number( p_column_ref in varchar2 ) return number
 as
-    l_column_number     number;
+    l_returnvalue       number;
     l_char_num          number;
     l_power             number;
     l_factor            decimal;
@@ -334,11 +334,11 @@ begin
     for i in 1..length( p_column_ref ) loop
         l_char_num := ascii( substr( p_column_ref, i, 1 ));
         l_factor := ( l_char_num - 65 ) + 1;
-        l_column_number := ( l_factor * power( 26, l_power )) + NVL( l_column_number, 0 );
+        l_returnvalue := ( l_factor * power( 26, l_power )) + NVL( l_returnvalue, 0 );
         l_power := l_power - 1;
     end loop;
 
-    return l_column_number;
+    return l_returnvalue;
 
 end get_xlsx_column_number;
 
@@ -347,7 +347,7 @@ function get_xlsx_column_ref( p_column_number in number ) return varchar2
 as
     l_dividend      decimal;
     l_modulo        decimal;
-    l_column_name   varchar2(3);
+    l_returnvalue   varchar2(3);
 begin
 
     /*
@@ -368,11 +368,11 @@ begin
 
     while l_dividend > 0 loop
         l_modulo := mod( l_dividend - 1, 26 );
-        l_column_name := to_char( chr( l_modulo + 65 )) || l_column_name;
+        l_returnvalue := to_char( chr( l_modulo + 65 )) || l_returnvalue;
         l_dividend := (( l_dividend - l_modulo ) / 26 );
     end loop;
 
-    return l_column_name;
+    return l_returnvalue;
 
 end get_xlsx_column_ref;
 

--- a/ora/ooxml_util_pkg.pkb
+++ b/ora/ooxml_util_pkg.pkb
@@ -308,63 +308,71 @@ begin
 end get_xlsx_properties;
 
 
-function get_xlsx_column_number (p_column_ref in varchar2) return number
+function get_xlsx_column_number( p_column_ref in varchar2 ) return number
 as
-  l_returnvalue number;
+    l_column_number     number;
+    l_char_num          number;
+    l_power             number;
+    l_factor            decimal;
 begin
 
-  /*
- 
-  Purpose:      get column number from column reference
- 
-  Remarks:      
- 
-  Who     Date        Description
-  ------  ----------  --------------------------------
-  MBR     11.07.2011  Created
- 
-  */
+    /*
 
-  if length(p_column_ref) > 1 then
-    l_returnvalue := ascii(substr(p_column_ref,1,1)) - 64;
-    l_returnvalue := l_returnvalue * 26;
-    l_returnvalue := l_returnvalue + (ascii(substr(p_column_ref,2,1)) - 64);
-  else
-    l_returnvalue := ascii(p_column_ref) - 64;
-  end if; 
-  
-  return l_returnvalue;
-  
+    Purpose:      get column number from column reference
+
+    Remarks:      
+
+    Who     Date        Description
+    ------  ----------  --------------------------------
+    MBR     11.07.2011  Created
+    JMW     29.11.2016  Modified to support columns up to the limit (currently XFD or 16384)
+
+    */
+
+    l_power := length( p_column_ref ) - 1;
+
+    for i in 1..length( p_column_ref ) loop
+        l_char_num := ascii( substr( p_column_ref, i, 1 ));
+        l_factor := ( l_char_num - 65 ) + 1;
+        l_column_number := ( l_factor * power( 26, l_power )) + NVL( l_column_number, 0 );
+        l_power := l_power - 1;
+    end loop;
+
+    return l_column_number;
+
 end get_xlsx_column_number;
 
 
-function get_xlsx_column_ref (p_column_number in varchar2) return varchar2
+function get_xlsx_column_ref( p_column_number in number ) return varchar2
 as
-  l_offset number;
-  l_returnvalue varchar2(2);
+    l_dividend      decimal;
+    l_modulo        decimal;
+    l_column_name   varchar2(3);
 begin
-  
-  /*
- 
-  Purpose:      get column reference from column number
- 
-  Remarks:      
- 
-  Who     Date        Description
-  ------  ----------  --------------------------------
-  MBR     11.07.2011  Created
- 
-  */
 
-  if p_column_number < 27 then
-    l_returnvalue := chr(p_column_number + 64);
-  else
-    l_offset := trunc(p_column_number/26);
-    l_returnvalue := chr(l_offset + 64);
-    l_returnvalue := l_returnvalue || chr(p_column_number - (l_offset * 26) + 64);
-  end if; 
-  
-  return l_returnvalue;
+    /*
+
+    Purpose:      get column reference from column number
+
+    Remarks:      
+
+    Who     Date        Description
+    ------  ----------  --------------------------------
+    MBR     11.07.2011  Created
+    JMW     29.11.2016  Modified to support columns up to the limit (currently XFD or 16384)
+                         and to fix the bug where the '@' is returned at multiples of 26
+
+    */
+
+    l_dividend := p_column_number;
+
+    while l_dividend > 0 loop
+        l_modulo := mod( l_dividend - 1, 26 );
+        l_column_name := to_char( chr( l_modulo + 65 )) || l_column_name;
+        l_dividend := (( l_dividend - l_modulo ) / 26 );
+    end loop;
+
+    return l_column_name;
 
 end get_xlsx_column_ref;
 
@@ -879,6 +887,3 @@ end get_pptx_plaintext;
 
 end ooxml_util_pkg;
 /
- 
-
-

--- a/ora/ooxml_util_pkg.pks
+++ b/ora/ooxml_util_pkg.pks
@@ -107,7 +107,7 @@ as
   function get_xlsx_column_number (p_column_ref in varchar2) return number;
 
   -- get column reference from column number
-  function get_xlsx_column_ref (p_column_number in varchar2) return varchar2;
+  function get_xlsx_column_ref (p_column_number in number) return varchar2;
 
   -- get cell value from XLSX file
   function get_xlsx_cell_value (p_xlsx in blob,
@@ -149,4 +149,3 @@ as
 
 end ooxml_util_pkg;
 /
-


### PR DESCRIPTION
Modified the ooxml_util_pkg.get_xlsx_column_ref and the
ooxml_util_pkg.get_xlsx_column_number functions to support columns up to
the limit (currently XFD or 16384) and in
ooxml_util_pkg.get_xlsx_column_ref to fix the bug where the '@' is
returned at multiples of 26.