### PR TITLE
Update ora/xml_util_pkg.pkb to fix #27

### DIFF
--- a/ora/xml_util_pkg.pkb
+++ b/ora/xml_util_pkg.pkb
@@ -10,6 +10,9 @@ as
   Who     Date        Description
   ------  ----------  -------------------------------------
   FDL     03.05.2007  Created
+  JMW     07.11.2025  Added get_unescaped_string()
+                       so that special characters
+                       in the return value are not escaped
 
   */
   
@@ -502,3 +505,4 @@ end extract_value_number;
 
 end xml_util_pkg;
 /
+

--- a/ora/xml_util_pkg.pkb
+++ b/ora/xml_util_pkg.pkb
@@ -303,11 +303,14 @@ begin
   Who     Date        Description
   ------  ----------  -------------------------------------
   MBR     07.12.2010  Created
+  JMW     12.04.2018  Changed the use of XMLType.extract(xpath).getStringVal()
+                       to EXTRACTVALUE(XMLType, xpath) so that special characters
+                       are not escaped
   
   */
   
   begin
-    select xmltype(p_tag).extract('//@' || p_attr_name).getstringval()
+    select extractvalue( xmltype(p_tag), '//@' || p_attr_name )
     into l_returnvalue
     from dual;
   exception
@@ -339,11 +342,16 @@ begin
   Who     Date        Description
   ------  ----------  --------------------------------
   MBR     27.01.2011  Created
+  JMW     12.04.2018  Changed the use of XMLType.extract(xpath).getStringVal()
+                       to EXTRACTVALUE(XMLType, xpath) so that special characters
+                       are not escaped
  
   */
 
   begin 
-    l_returnvalue := p_xml.extract(p_xpath, p_namespace).getstringval();
+    select extractvalue( p_xml, p_xpath, p_namespace )
+    into l_returnvalue
+    from dual;
   exception
     when others then
       l_returnvalue := p_default_value;
@@ -372,14 +380,21 @@ begin
   Who     Date        Description
   ------  ----------  --------------------------------
   MBR     27.01.2011  Created
+  JMW     12.04.2018  Changed the use of XMLType.extract(xpath).getStringVal()
+                       to EXTRACTVALUE(XMLType, xpath) so that special characters
+                       are not escaped
  
   */
  
   begin 
     if p_date_format is not null then
-      l_returnvalue := to_date(p_xml.extract(p_xpath, p_namespace).getstringval(), p_date_format);
+      select to_date( extractvalue( p_xml, p_xpath, p_namespace ), p_date_format )
+      into l_returnvalue
+      from dual;
     else
-      l_returnvalue := to_date(substr(p_xml.extract(p_xpath, p_namespace).getstringval(), 1, 19), 'YYYY-MM-DD"T"hh24:mi:ss');
+      select to_date( substr( extractvalue( p_xml, p_xpath, p_namespace ), 1, 19 ), 'YYYY-MM-DD"T"hh24:mi:ss' )
+      into l_returnvalue
+      from dual;
     end if;
   exception
     when others then
@@ -408,11 +423,16 @@ begin
   Who     Date        Description
   ------  ----------  --------------------------------
   MBR     27.01.2011  Created
+  JMW     12.04.2018  Changed the use of XMLType.extract(xpath).getStringVal()
+                       to EXTRACTVALUE(XMLType, xpath) so that special characters
+                       are not escaped
  
   */
  
   begin 
-    l_returnvalue := to_number(p_xml.extract(p_xpath, p_namespace).getstringval());
+    select to_number( extractvalue( p_xml, p_xpath, p_namespace ) )
+    into l_returnvalue
+    from dual;
   exception
     when others then
       l_returnvalue := p_default_value;

--- a/ora/xml_util_pkg.pks
+++ b/ora/xml_util_pkg.pks
@@ -37,12 +37,15 @@ as
                        p_name in varchar2,
                        p_regional_settings in t_regional_settings := null,
                        p_raise_error_if_parse_error in boolean := false) return number;
-
+  
   -- return a string from DOM node
   function get_string (p_node in dbms_xmldom.domnode,
                        p_name in varchar2,
                        p_trim_str in boolean := true) return varchar2;
-                       
+  
+  -- get unescaped string
+  function get_unescaped_string( p_escaped in varchar2 ) return varchar2;
+  
   -- build tagged string
   function tag_str (p_str in varchar2,
                     p_tag_name in varchar2) return varchar2;
@@ -80,4 +83,5 @@ as
 
 end xml_util_pkg;
 /
+
 

--- a/ora/xml_util_pkg.pks
+++ b/ora/xml_util_pkg.pks
@@ -10,6 +10,9 @@ as
   Who     Date        Description
   ------  ----------  -------------------------------------
   FDL     03.05.2007  Created
+  JMW     07.11.2025  Added get_unescaped_string()
+                       so that special characters
+                       in the return value are not escaped
 
   */
   
@@ -83,5 +86,6 @@ as
 
 end xml_util_pkg;
 /
+
 
 


### PR DESCRIPTION
Modified the xml_util_pkg and changed the use of XMLType.extract(xpath).getStringVal() to EXTRACTVALUE(XMLType, xpath) so that special characters are not escaped.