### PR TITLE
Compiling ooxml util pkg.pkb raises ora 00913 too many values #74

### DIFF
--- a/ora/ooxml_util_pkg.pkb
+++ b/ora/ooxml_util_pkg.pkb
@@ -889,4 +889,3 @@ end get_pptx_plaintext;
 
 end ooxml_util_pkg;
 /
-

--- a/ora/ooxml_util_pkg.pkb
+++ b/ora/ooxml_util_pkg.pkb
@@ -80,7 +80,7 @@ begin
     
     l_xml := get_xml( p_xlsx, 'xl/workbook.xml' );
     
-    select xml.r_id, xml.sheetid, xml.name
+    select xml.r_id, xml.sheetid, xml.name, xml.state
         bulk collect into l_returnvalue
       from xmltable( xmlnamespaces( default 'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
                          'http://schemas.openxmlformats.org/officeDocument/2006/relationships' AS "r" ),
@@ -889,3 +889,4 @@ end get_pptx_plaintext;
 
 end ooxml_util_pkg;
 /
+


### PR DESCRIPTION
Added the state column back to the query in get_worksheets_list(), which was somehow removed when the ORDER BY clause was removed.

resolves #74